### PR TITLE
fix: Properly handle as-set when one is the origin asn in the as-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .mypy_cache
 .tmpdirs
 .pytest_cache
+venv/
 
 syntax: glob
 __pycache__

--- a/validator/tests/test_alicelg.py
+++ b/validator/tests/test_alicelg.py
@@ -30,7 +30,7 @@ PAYLOAD_ROUTES = {
         {
             "network": "192.0.2.0/24",
             "bgp": {
-                "as_path": [64501, 64502],
+                "as_path": ["64501", "64502"],
                 "communities": [[64501, 1], [64501, 2]],
                 "large_communities": [[64501, 10, 20]],
             },

--- a/validator/tests/test_birdseye.py
+++ b/validator/tests/test_birdseye.py
@@ -16,7 +16,7 @@ PAYLOAD_ROUTES = {
         {
             "network": "192.0.2.0/24",
             "bgp": {
-                "as_path": [64501, 64502],
+                "as_path": ["64501", "64502"],
                 "communities": [[64501, 1], [64501, 2]],
                 "large_communities": [[64501, 10, 20]],
             },

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -47,8 +47,15 @@ async def route_tasks_to_route_entries(tasks, source_name: str):
                 source += " route server " + metadata["route_server"]
             if "peer_name" in metadata:
                 source += " peer " + metadata["peer_name"]
+            origin_raw = imported_route["bgp"]["as_path"][-1]
+            origin = None
+            if "{" in origin_raw:
+                # as-set as first ASN
+                pass
+            else:
+                origin = int(origin_raw)
             route_entry = RouteEntry(
-                origin=int(imported_route["bgp"]["as_path"][-1]),
+                origin=origin,
                 aspath=" ".join([str(asn) for asn in imported_route["bgp"]["as_path"]]),
                 prefix=imported_route["network"],
                 peer_ip=metadata["peer_ip"],


### PR DESCRIPTION
int() throws an exception if the first asn in the path is an as-set (e.g. {65000}).

Detect as-set and assign None, otherwise int.  Fix integration tests mock payloads to match the actual payload types.