### PR TITLE
Update alice-lg RPKI invalid community code for new config options

### DIFF
--- a/validator/roa.py
+++ b/validator/roa.py
@@ -20,7 +20,7 @@ def parse_roas(roa_file: IO[bytes]) -> Tuple[radix.Radix, int]:
             node.data["roas"] = list()
         node.data["roas"].append(
             {
-                "asn": int(roa["asn"].replace("AS", "")),
+                "asn": int(str(roa["asn"]).replace("AS", "")),
                 "max_length": roa["maxLength"],
             }
         )

--- a/validator/run.py
+++ b/validator/run.py
@@ -37,11 +37,9 @@ async def run(
         routes_generator = parse_mrt(mrt_file, path_bgpdump)
     elif alice_url:
         if not communities_expected_invalid:
-            alice_invalid_community = await alicelg.query_rpki_invalid_community(
+            communities_expected_invalid = await alicelg.query_rpki_invalid_community(
                 alice_url, ssl_verify
             )
-            if alice_invalid_community:
-                communities_expected_invalid = {alice_invalid_community}
         routes_generator = alicelg.get_routes(alice_url, alice_rs_group, ssl_verify)
     elif birdseye_url:
         routes_generator = birdseye.get_routes(birdseye_url, ssl_verify)


### PR DESCRIPTION
Alice now supports multiple communities for RPKI invalids, rather
than just one. This change should be compatible with both formats.

New example: https://lg.khi.de-cix.net/api/v1/config
Old example: https://lg.megaport.com/api/v1/config

I did some quick testing only.
